### PR TITLE
Made new intermediate reaction omkm._OMKMReaction

### DIFF
--- a/pmutt/__init__.py
+++ b/pmutt/__init__.py
@@ -10,7 +10,7 @@ pmutt
 # present, too:
 #
 name = 'pmutt'
-__version__ = '1.2.21'
+__version__ = '1.2.21.flb'
 
 import os
 import inspect


### PR DESCRIPTION
_OMKMReaction contains most of what was previously in
omkm.SurfaceReaction, but not what is only surface specific.
The new omkm.SurfaceReaction inherits from _OMKMReaction, adds
on what was not put into _OMKMReaction and
is as a result unchanged from previously. In addition omkm.GasReaction
is added. This also inherits from _OMKMReaction. For now the only
additions from _OMKMReaction are write functions.